### PR TITLE
Fix cryptography deprecation warnings and future warning in get_fingerprint

### DIFF
--- a/httpsig_cffi/sign.py
+++ b/httpsig_cffi/sign.py
@@ -57,9 +57,8 @@ class Signer(object):
 
     def _sign_rsa(self, data):
         if isinstance(data, six.string_types): data = data.encode("ascii")
-        r = self._rsa_private.signer(padding.PKCS1v15(), self._rsahash())
-        r.update(data)
-        return r.finalize()
+        r = self._rsa_private.sign(data, padding.PKCS1v15(), self._rsahash())
+        return r
 
     def _sign_hmac(self, data):
         if isinstance(data, six.string_types): data = data.encode("ascii")

--- a/httpsig_cffi/utils.py
+++ b/httpsig_cffi/utils.py
@@ -152,7 +152,7 @@ def get_fingerprint(key):
     if key.startswith('ssh-rsa'):
         key = key.split(' ')[1]
     else:
-        regex = r'\-{4,5}[\w|| ]+\-{4,5}'
+        regex = r'\-{4,5}[\w\|\| ]+\-{4,5}'
         key = re.split(regex, key)[1]
 
     key = key.replace('\n', '')

--- a/httpsig_cffi/verify.py
+++ b/httpsig_cffi/verify.py
@@ -32,12 +32,8 @@ class Verifier(Signer):
 
         if self.sign_algorithm == 'rsa':
 
-            h = self._rsa_public.verifier(b64decode(signature),
-                                          padding.PKCS1v15(),
-                                          self._rsahash())
-            h.update(data)
             try:
-                h.verify()
+                h = self._rsa_public.verify(b64decode(signature), data, padding.PKCS1v15(), self._rsahash())
                 return True
             except InvalidSignature:
                 return False


### PR DESCRIPTION
* Fix deprecation warnings

The signer and verifier methods have been deprecated in
cryptography since version 2.0

* Fix futurewarning in regular expression in get_fingerprint